### PR TITLE
Allow notifications from places other than observer.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,10 @@ import asyncio
 
 import dotenv
 
-from configuration.config import get_config
+from configuration.config import ConfigError, get_config, get_notification_config
 from configuration.types import Configuration
+from observer.message import Message, MessageLevel
+from observer.notification import log_message
 from observer.observer import observer_loop
 
 
@@ -13,5 +15,15 @@ def main(config: Configuration):
 
 if __name__ == "__main__":
     dotenv.load_dotenv()
-    config = get_config()
-    main(config)
+    try:
+        config = get_config()
+        main(config)
+    except ConfigError as ex:
+        log_message(
+            get_notification_config(),
+            Message.builder()
+            .build(
+                MessageLevel.CRITICAL,
+                repr(ex),
+            ),
+        )

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     try:
         config = get_config()
         main(config)
-    except ConfigError as ex:
+    except Exception as ex:
         log_message(
             get_notification_config(),
             Message.builder()
@@ -27,3 +27,4 @@ if __name__ == "__main__":
                 repr(ex),
             ),
         )
+    

--- a/observer/notification.py
+++ b/observer/notification.py
@@ -1,8 +1,10 @@
+import logging
 from typing import Any
 
 import requests
 
 from configuration.types import (
+    Notification,
     NotificationDiscord,
     NotificationGeneric,
     NotificationSlack,
@@ -10,6 +12,19 @@ from configuration.types import (
 )
 
 from .message import Message
+
+LOGGER = logging.getLogger(__name__)
+
+
+def log_message(notification: Notification, message: Message):
+    LOGGER.log(message.level.value, message.message)
+
+    lvl_msg = f"{message.level.name} {message.message}"
+
+    notify_discord(notification.discord, lvl_msg)
+    notify_slack(notification.slack, lvl_msg)
+    notify_telegram(notification.telegram, lvl_msg)
+    notify_generic(notification.generic, message)
 
 
 def notify(


### PR DESCRIPTION
This refactor allows sending notifications to the configured services in other locations other than observer.py, this allows notifying the user about connection errors to the RPC nodes, maybe they're offline, maybe they're unhealthy, either way, now we can know